### PR TITLE
fix contract violation in page-interactive? and page-loaded?

### DIFF
--- a/marionette-lib/marionette/page.rkt
+++ b/marionette-lib/marionette/page.rkt
@@ -167,11 +167,15 @@ SCRIPT
 
 (define/contract (page-interactive? p)
   (-> page? boolean?)
-  (member (page-readystate p) '("interactive" "complete")))
+  (if (member (page-readystate p) '("interactive" "complete"))
+      #t
+      #f))
 
 (define/contract (page-loaded? p)
   (-> page? boolean?)
-  (member (page-readystate p) '("complete")))
+  (if (member (page-readystate p) '("complete"))
+      #t
+      #f))
 
 (define wait-for-element-script #<<SCRIPT
 const [selector, timeout, mustBeVisible] = arguments;


### PR DESCRIPTION
; page-loaded?: broke its own contract
;   promised: boolean?
;   produced: '("complete")
;   in: the range of
;       (-> page? boolean?)
;   contract from: (function page-loaded?)
;   blaming: (function page-loaded?)
;    (assuming the contract is correct)
;   at: <pkgs>/marionette-lib/marionette/page.rkt:172.18

'member' can return list rather than boolean, so wrapped with 'if'