### PR TITLE
Fixing in-hash error when a port is provided and user.js isnt

### DIFF
--- a/marionette-lib/browser.rkt
+++ b/marionette-lib/browser.rkt
@@ -97,7 +97,8 @@
    (handle-evt
     (marionette-get-capabilities! (browser-marionette b))
     (match-lambda
-      [(hash-table ('capabilities caps))
+      [(or (hash-table ['capabilities caps])
+           (hash-table ['value (hash-table ['capabilities caps])]))
        (jsexpr->capabilities caps)]))))
 
 (define (browser-pages b)

--- a/marionette-lib/support/user.js
+++ b/marionette-lib/support/user.js
@@ -2,6 +2,7 @@ user_pref("marionette.port", @(or port 2828));
 user_pref("browser.startup.homepage_override.mstone", "ignore");
 user_pref("datareporting.policy.firstRunURL", "");
 
-@in[(k v) (in-hash user.js)]{
-  user_pref(@~s[k], @~js[v]);
-}
+@when[(hash? user.js)
+      @in[(k v) (in-hash user.js)]{
+	  user_pref(@~s[k], @~js[v]);
+      }]

--- a/marionette-lib/support/user.js
+++ b/marionette-lib/support/user.js
@@ -2,7 +2,6 @@ user_pref("marionette.port", @(or port 2828));
 user_pref("browser.startup.homepage_override.mstone", "ignore");
 user_pref("datareporting.policy.firstRunURL", "");
 
-@when[(hash? user.js)
-      @in[(k v) (in-hash user.js)]{
-	  user_pref(@~s[k], @~js[v]);
-      }]
+@in[(k v) (in-hash (or user.js (hash)))]{
+  user_pref(@~s[k], @~js[v]);
+}


### PR DESCRIPTION
If one uses the current master branch, an error is obtained when a port is passed but user.js has the default value #f.

For example if one runs:

`(start-marionette! #:port 55000)`

then one gets the error

in-hash: contract violation
  expected: hash?
  given: #f

Now, this happend because in /marionette-lib/support/user.js the code (in-hash user.js) runs even when user.js is #f.
This pull request solved this bug.